### PR TITLE
Add update-task-snooze-date tool for task scheduling

### DIFF
--- a/.changeset/add-task-snooze-update.md
+++ b/.changeset/add-task-snooze-update.md
@@ -1,0 +1,10 @@
+---
+"mcp-sunsama": minor
+---
+
+Add update-task-snooze-date tool for comprehensive task scheduling
+
+- New `update-task-snooze-date` MCP tool enables moving tasks between days, scheduling backlog tasks, and unscheduling tasks to backlog
+- Supports timezone handling and response payload limiting options  
+- Uses existing sunsama-api `updateTaskSnoozeDate` method with proper Zod schema validation
+- Addresses three key user stories through single unified tool interface

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,9 @@ When updating the version:
 1. Update `package.json` version (done automatically by changesets)
 2. Manually update the FastMCP server version in `src/main.ts`
 3. Both versions must be identical for consistency
+
+## Git Rules
+
+**IMPORTANT**: Never commit the `dev/` directory or any of its files to git. This directory contains development data including sample API responses and testing data that should remain local only.
+
+**IMPORTANT**: Never include "Claude" in git commit messages. Keep commit messages professional and focused on the actual changes made.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Model Context Protocol (MCP) server that provides comprehensive task managemen
 ### Task Management
 - **Create Tasks** - Create new tasks with notes, time estimates, due dates, and stream assignments
 - **Read Tasks** - Get tasks by day with completion filtering, access backlog tasks
-- **Update Tasks** - Mark tasks as complete with custom timestamps
+- **Update Tasks** - Mark tasks as complete with custom timestamps, reschedule tasks or move to backlog
 - **Delete Tasks** - Permanently remove tasks from your workspace
 
 ### User & Stream Operations
@@ -92,6 +92,7 @@ Add this configuration to your Claude Desktop MCP settings:
 - `get-tasks-by-day` - Get tasks for a specific day with completion filtering
 - `get-tasks-backlog` - Get backlog tasks
 - `update-task-complete` - Mark tasks as complete
+- `update-task-snooze-date` - Reschedule tasks to different dates or move to backlog
 - `delete-task` - Delete tasks permanently
 
 ### User & Stream Operations

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@types/papaparse": "^5.3.16",
         "fastmcp": "2.1.3",
         "papaparse": "^5.5.3",
-        "sunsama-api": "0.2.1",
+        "sunsama-api": "0.3.0",
         "zod": "3.24.4",
       },
       "devDependencies": {
@@ -428,7 +428,7 @@
 
     "strtok3": ["strtok3@10.3.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw=="],
 
-    "sunsama-api": ["sunsama-api@0.2.1", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "tough-cookie": "^5.1.2", "tslib": "^2.8.1" } }, "sha512-G98BCWEZ+Du4NGyEL9SxMqwmEfmZrgKHwTdL3nAVUua4X9toTI9NIiN+zlUFKqN+n+iaF5Xsz0g3lAC/axZcDQ=="],
+    "sunsama-api": ["sunsama-api@0.3.0", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "tough-cookie": "^5.1.2", "tslib": "^2.8.1", "zod": "^3.25.64" } }, "sha512-xXgwm2WSVHpHU/0yhOK/3TUQlRSPtQS0UF/+q0liHJiZh1LjUJwgnmaK5rZcEvJ2s1rFVqWgm6GTMZ3t2r5ynw=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
@@ -511,5 +511,7 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "raw-body/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "sunsama-api/zod": ["zod@3.25.64", "", {}, "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/papaparse": "^5.3.16",
     "fastmcp": "2.1.3",
     "papaparse": "^5.5.3",
-    "sunsama-api": "0.2.1",
+    "sunsama-api": "0.3.0",
     "zod": "3.24.4"
   },
   "devDependencies": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -61,6 +61,14 @@ export const deleteTaskSchema = z.object({
   wasTaskMerged: z.boolean().optional().describe("Whether the task was merged before deletion"),
 });
 
+// Update task snooze date parameters
+export const updateTaskSnoozeDateSchema = z.object({
+  taskId: z.string().min(1, "Task ID is required").describe("The ID of the task to reschedule"),
+  newDay: z.string().date("Must be a valid date in YYYY-MM-DD format").nullable().describe("Target date in YYYY-MM-DD format, or null to move to backlog"),
+  timezone: z.string().optional().describe("Timezone string (e.g., 'America/New_York'). If not provided, uses user's default timezone"),
+  limitResponsePayload: z.boolean().optional().describe("Whether to limit the response payload size"),
+});
+
 /**
  * Response Type Schemas (for validation and documentation)
  */
@@ -159,6 +167,7 @@ export type GetStreamsInput = z.infer<typeof getStreamsSchema>;
 export type CreateTaskInput = z.infer<typeof createTaskSchema>;
 export type UpdateTaskCompleteInput = z.infer<typeof updateTaskCompleteSchema>;
 export type DeleteTaskInput = z.infer<typeof deleteTaskSchema>;
+export type UpdateTaskSnoozeDateInput = z.infer<typeof updateTaskSnoozeDateSchema>;
 
 export type User = z.infer<typeof userSchema>;
 export type Task = z.infer<typeof taskSchema>;


### PR DESCRIPTION
## Summary
- Add new `update-task-snooze-date` MCP tool for comprehensive task scheduling
- Enables moving tasks between days, scheduling backlog tasks, and unscheduling tasks
- Implements proper Zod schema validation with YYYY-MM-DD date format
- Uses existing sunsama-api `updateTaskSnoozeDate` method

## Changes
- Added `updateTaskSnoozeDateSchema` to schemas.ts with date validation
- Implemented `update-task-snooze-date` tool in main.ts with timezone support
- Updated README.md documentation with new tool capabilities
- Added changeset for minor version bump