### PR TITLE
feat: add get-task-by-id tool for retrieving specific tasks

### DIFF
--- a/.changeset/get-task-by-id.md
+++ b/.changeset/get-task-by-id.md
@@ -1,0 +1,12 @@
+---
+"mcp-sunsama": minor
+---
+
+Add get-task-by-id tool for retrieving specific tasks by their unique identifier
+
+- Add `get-task-by-id` MCP tool that retrieves a specific task by its ID
+- Add `getTaskByIdSchema` with taskId parameter validation
+- Return complete task object if found, null if not found
+- Follow standard tool patterns for authentication, error handling, and logging
+- Update documentation in README.md and CLAUDE.md
+- Maintain consistent JSON response format for single object retrieval

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Optional:
 
 ### Task Operations
 Full CRUD support:
-- **Read**: `get-tasks-by-day`, `get-tasks-backlog`, `get-archived-tasks`, `get-streams`
+- **Read**: `get-tasks-by-day`, `get-tasks-backlog`, `get-archived-tasks`, `get-task-by-id`, `get-streams`
 - **Write**: `create-task`, `update-task-complete`, `update-task-snooze-date`, `update-task-backlog`, `delete-task`
 
 Task read operations support response trimming. `get-tasks-by-day` includes completion filtering. `get-archived-tasks` includes enhanced pagination with hasMore flag for LLM decision-making.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Add this configuration to your Claude Desktop MCP settings:
 - `get-tasks-by-day` - Get tasks for a specific day with completion filtering
 - `get-tasks-backlog` - Get backlog tasks
 - `get-archived-tasks` - Get archived tasks with pagination (includes hasMore flag for LLM context)
+- `get-task-by-id` - Get a specific task by its ID
 - `update-task-complete` - Mark tasks as complete
 - `update-task-snooze-date` - Reschedule tasks to different dates
 - `update-task-backlog` - Move tasks to the backlog

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -23,6 +23,11 @@ export const getArchivedTasksSchema = z.object({
   limit: z.number().int().min(1).max(1000).optional().describe("Maximum number of tasks to return (defaults to 100)"),
 });
 
+// Get task by ID parameters
+export const getTaskByIdSchema = z.object({
+  taskId: z.string().min(1, "Task ID is required").describe("The ID of the task to retrieve"),
+});
+
 /**
  * User Operation Schemas
  */
@@ -175,6 +180,7 @@ export type CompletionFilter = z.infer<typeof completionFilterSchema>;
 export type GetTasksByDayInput = z.infer<typeof getTasksByDaySchema>;
 export type GetTasksBacklogInput = z.infer<typeof getTasksBacklogSchema>;
 export type GetArchivedTasksInput = z.infer<typeof getArchivedTasksSchema>;
+export type GetTaskByIdInput = z.infer<typeof getTaskByIdSchema>;
 export type GetUserInput = z.infer<typeof getUserSchema>;
 export type GetStreamsInput = z.infer<typeof getStreamsSchema>;
 


### PR DESCRIPTION
## Summary
- Add `get-task-by-id` MCP tool that retrieves a specific task by its ID
- Enables targeted task retrieval without filtering through larger collections
- Returns complete task object if found, null if not found

## Changes
- Add `getTaskByIdSchema` with taskId parameter validation in `src/schemas.ts`
- Implement `get-task-by-id` tool following standard patterns in `src/main.ts`
- Update tool documentation in server instructions and resource docs
- Add tool to README.md and CLAUDE.md documentation
- Create changeset for minor version bump

## Implementation Details
- Uses `SunsamaClient.getTaskById(taskId)` method from sunsama-api
- Follows established patterns for authentication, error handling, and logging
- Returns JSON format for single object consistency (vs TSV for arrays)
- Handles both successful retrieval and task-not-found scenarios gracefully

## Test Plan
- [x] TypeScript compilation passes
- [x] All existing tests continue to pass
- [x] Tool can be tested via MCP Inspector
- [x] Proper error handling for invalid/missing task IDs
- [x] Authentication requirements enforced