### PR TITLE
feat: add update-task-notes tool

### DIFF
--- a/.changeset/add-update-task-notes.md
+++ b/.changeset/add-update-task-notes.md
@@ -1,0 +1,12 @@
+---
+"mcp-sunsama": minor
+---
+
+Add update-task-notes tool for updating task notes content
+
+- New `update-task-notes` tool supports updating task notes with HTML or Markdown content
+- Accepts either `{html: string}` or `{markdown: string}` content format (mutually exclusive)
+- Includes optional `limitResponsePayload` parameter for response optimization
+- Integrates with Sunsama's collaborative editing system for proper synchronization
+- Follows established patterns for tool implementation and error handling
+- Updates API documentation, README, and CLAUDE.md with new tool information

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Optional:
 ### Task Operations
 Full CRUD support:
 - **Read**: `get-tasks-by-day`, `get-tasks-backlog`, `get-archived-tasks`, `get-task-by-id`, `get-streams`
-- **Write**: `create-task`, `update-task-complete`, `update-task-planned-time`, `update-task-snooze-date`, `update-task-backlog`, `delete-task`
+- **Write**: `create-task`, `update-task-complete`, `update-task-planned-time`, `update-task-notes`, `update-task-snooze-date`, `update-task-backlog`, `delete-task`
 
 Task read operations support response trimming. `get-tasks-by-day` includes completion filtering. `get-archived-tasks` includes enhanced pagination with hasMore flag for LLM decision-making.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Add this configuration to your Claude Desktop MCP settings:
 - `get-task-by-id` - Get a specific task by its ID
 - `update-task-complete` - Mark tasks as complete
 - `update-task-planned-time` - Update the planned time (time estimate) for tasks
+- `update-task-notes` - Update task notes content with HTML or Markdown
 - `update-task-snooze-date` - Reschedule tasks to different dates
 - `update-task-backlog` - Move tasks to the backlog
 - `delete-task` - Delete tasks permanently

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@types/papaparse": "^5.3.16",
         "fastmcp": "3.3.1",
         "papaparse": "^5.5.3",
-        "sunsama-api": "0.7.0",
+        "sunsama-api": "0.8.0",
         "zod": "3.24.4",
       },
       "devDependencies": {
@@ -57,6 +57,8 @@
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.12.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw=="],
 
@@ -282,6 +284,8 @@
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
+    "marked": ["marked@14.1.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mcp-proxy": ["mcp-proxy@5.1.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "eventsource": "^4.0.0", "yargs": "^18.0.0" }, "bin": { "mcp-proxy": "dist/bin/mcp-proxy.js" } }, "sha512-6pfAdXFOvfpqse9dMLuQo8WTSFdD0al8vhr0Nx5EWv+dR6aTAHphdQj9NUP2xej2bhaWzJ5p8BRwbvXufOjJHA=="],
@@ -426,7 +430,7 @@
 
     "strtok3": ["strtok3@10.3.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw=="],
 
-    "sunsama-api": ["sunsama-api@0.7.0", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "tough-cookie": "^5.1.2", "tslib": "^2.8.1", "yjs": "^13.6.27", "zod": "^3.25.64" } }, "sha512-/wPvJrtE0rUftl7c+OuQdu27OYkTvd23jzcQoAUP2SilQ6QYnFeG/Fjdf6nfl/MFuz5B8mpviGJdSgqYjAkd0g=="],
+    "sunsama-api": ["sunsama-api@0.8.0", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "marked": "^14.1.3", "tough-cookie": "^5.1.2", "tslib": "^2.8.1", "turndown": "^7.2.0", "yjs": "^13.6.27", "zod": "^3.25.64" } }, "sha512-EiUqEc2OIDsmfCHQX54Pu+xZDfJBTMjHAcwhWqHVIWTp2emMyitUuSDvABEqupoXrzITZw+XW0lxNZUQaW4lqQ=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
@@ -445,6 +449,8 @@
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.0", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/papaparse": "^5.3.16",
     "fastmcp": "3.3.1",
     "papaparse": "^5.5.3",
-    "sunsama-api": "0.7.0",
+    "sunsama-api": "0.8.0",
     "zod": "3.24.4"
   },
   "devDependencies": {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -94,6 +94,20 @@ export const updateTaskPlannedTimeSchema = z.object({
   limitResponsePayload: z.boolean().optional().describe("Whether to limit the response payload size"),
 });
 
+// Update task notes parameters
+export const updateTaskNotesSchema = z.object({
+  taskId: z.string().min(1, "Task ID is required").describe("The ID of the task to update notes for"),
+  content: z.union([
+    z.object({ 
+      html: z.string().describe("HTML content for the task notes") 
+    }),
+    z.object({ 
+      markdown: z.string().describe("Markdown content for the task notes") 
+    })
+  ]).describe("Task notes content in either HTML or Markdown format"),
+  limitResponsePayload: z.boolean().optional().describe("Whether to limit the response payload size (defaults to true)"),
+});
+
 /**
  * Response Type Schemas (for validation and documentation)
  */
@@ -196,6 +210,7 @@ export type UpdateTaskCompleteInput = z.infer<typeof updateTaskCompleteSchema>;
 export type DeleteTaskInput = z.infer<typeof deleteTaskSchema>;
 export type UpdateTaskSnoozeDateInput = z.infer<typeof updateTaskSnoozeDateSchema>;
 export type UpdateTaskPlannedTimeInput = z.infer<typeof updateTaskPlannedTimeSchema>;
+export type UpdateTaskNotesInput = z.infer<typeof updateTaskNotesSchema>;
 
 export type User = z.infer<typeof userSchema>;
 export type Task = z.infer<typeof taskSchema>;


### PR DESCRIPTION
## Summary
- Add new `update-task-notes` tool for updating task notes content in Sunsama
- Support both HTML and Markdown content formats with automatic conversion
- Integrate with Sunsama's collaborative editing system for proper synchronization

## Changes Made
- **New Tool**: `update-task-notes` with comprehensive parameter validation
- **Content Formats**: Accepts either `{html: string}` or `{markdown: string}` (mutually exclusive)
- **Response Optimization**: Optional `limitResponsePayload` parameter (defaults to true)
- **Schema Validation**: Added Zod schema with proper type inference
- **Documentation**: Updated API docs, README.md, and CLAUDE.md
- **Error Handling**: Follows established patterns with structured logging

## API Interface
```typescript
{
  taskId: string (required),
  content: {html: string} | {markdown: string} (required),
  limitResponsePayload?: boolean (optional, default: true)
}
```

## Test Plan
- [x] TypeScript compilation passes
- [x] All existing tests pass
- [x] Schema validation works correctly
- [x] Tool integrates with existing MCP server architecture
- [x] Documentation updated across all relevant files
- [x] Changeset created for version management

## Integration Notes
- Uses sunsama-api's `updateTaskNotes` method with collaborative editing support
- Follows established tool implementation patterns
- Maintains compatibility with both stdio and HTTP transport modes
- Response format consistent with other task mutation tools