### PR TITLE
feat: refactor update-task-notes to use XOR schema pattern

### DIFF
--- a/.changeset/update-task-notes-xor-schema.md
+++ b/.changeset/update-task-notes-xor-schema.md
@@ -1,0 +1,11 @@
+---
+"mcp-sunsama": minor
+---
+
+Refactor update-task-notes schema to use XOR pattern for content parameters
+
+- Replace nested content object with separate html and markdown parameters
+- Implement XOR validation ensuring exactly one content type is provided
+- Add comprehensive test coverage for the new schema pattern
+- Update tool implementation to handle simplified parameter structure
+- Update documentation across README.md, CLAUDE.md, and API docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ All tools use Zod schemas from `schemas.ts`:
 - Automatic TypeScript inference
 - Comprehensive parameter documentation
 - Union types for completion filters
+- XOR schema patterns for mutually exclusive parameters (e.g., `update-task-notes` requires either `html` OR `markdown`, but not both)
 
 ## Key Patterns
 
@@ -106,6 +107,7 @@ server.addTool({
 
 - `src/main.ts`: FastMCP server setup and tool definitions
 - `src/schemas.ts`: Zod validation schemas for all tools
+- `src/schemas.test.ts`: Comprehensive test suite for all Zod schemas including parameter validation, response schemas, and XOR patterns
 - `src/auth/`: Authentication strategies per transport type
 - `src/config/`: Environment configuration and validation
 - `src/utils/`: Reusable utilities (client resolution, filtering, formatting)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Add this configuration to your Claude Desktop MCP settings:
 - `get-task-by-id` - Get a specific task by its ID
 - `update-task-complete` - Mark tasks as complete
 - `update-task-planned-time` - Update the planned time (time estimate) for tasks
-- `update-task-notes` - Update task notes content with HTML or Markdown
+- `update-task-notes` - Update task notes content (requires either `html` or `markdown` parameter)
 - `update-task-snooze-date` - Reschedule tasks to different dates
 - `update-task-backlog` - Move tasks to the backlog
 - `delete-task` - Delete tasks permanently

--- a/src/schemas.test.ts
+++ b/src/schemas.test.ts
@@ -12,6 +12,7 @@ import {
   updateTaskSnoozeDateSchema,
   updateTaskBacklogSchema,
   updateTaskPlannedTimeSchema,
+  updateTaskNotesSchema,
   userProfileSchema,
   groupSchema,
   userSchema,
@@ -349,6 +350,91 @@ describe("Tool Parameter Schemas", () => {
           taskId: "task-123" 
         })
       ).toThrow();
+    });
+  });
+
+  describe("updateTaskNotesSchema", () => {
+    test("should accept valid HTML content", () => {
+      const htmlInput = {
+        taskId: "task-123",
+        html: "<p>This is HTML content</p>",
+        limitResponsePayload: true,
+      };
+      expect(() => updateTaskNotesSchema.parse(htmlInput)).not.toThrow();
+    });
+
+    test("should accept valid Markdown content", () => {
+      const markdownInput = {
+        taskId: "task-123",
+        markdown: "# This is Markdown content",
+        limitResponsePayload: true,
+      };
+      expect(() => updateTaskNotesSchema.parse(markdownInput)).not.toThrow();
+    });
+
+    test("should accept minimal HTML input", () => {
+      const minimalHtmlInput = {
+        taskId: "task-123",
+        html: "<p>Simple HTML</p>",
+      };
+      expect(() => updateTaskNotesSchema.parse(minimalHtmlInput)).not.toThrow();
+    });
+
+    test("should accept minimal Markdown input", () => {
+      const minimalMarkdownInput = {
+        taskId: "task-123",
+        markdown: "Simple markdown",
+      };
+      expect(() => updateTaskNotesSchema.parse(minimalMarkdownInput)).not.toThrow();
+    });
+
+    test("should reject both HTML and Markdown provided", () => {
+      const invalidInput = {
+        taskId: "task-123",
+        html: "<p>HTML content</p>",
+        markdown: "Markdown content",
+      };
+      expect(() => updateTaskNotesSchema.parse(invalidInput)).toThrow();
+    });
+
+    test("should reject neither HTML nor Markdown provided", () => {
+      const invalidInput = {
+        taskId: "task-123",
+        limitResponsePayload: true,
+      };
+      expect(() => updateTaskNotesSchema.parse(invalidInput)).toThrow();
+    });
+
+    test("should reject empty task ID", () => {
+      expect(() =>
+        updateTaskNotesSchema.parse({
+          taskId: "",
+          html: "<p>Content</p>",
+        })
+      ).toThrow();
+      expect(() =>
+        updateTaskNotesSchema.parse({
+          markdown: "Content",
+        })
+      ).toThrow();
+    });
+
+    test("should accept empty HTML content", () => {
+      expect(() =>
+        updateTaskNotesSchema.parse({
+          taskId: "task-123",
+          html: "",
+        })
+      ).not.toThrow();
+    });
+
+    test("should accept empty Markdown content", () => {
+      expect(() =>
+        updateTaskNotesSchema.parse({
+          taskId: "task-123",
+          markdown: "",
+        })
+      ).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Refactored `update-task-notes` schema from nested content object to XOR pattern with separate `html` and `markdown` parameters
- Implemented comprehensive validation ensuring exactly one content type is provided
- Added extensive test coverage for the new XOR schema pattern
- Updated tool implementation to handle simplified parameter structure with `content = {type, value}` pattern
- Updated documentation across README.md, CLAUDE.md, and API docs resource

## Changes Made

### Schema Changes
- **`src/schemas.ts`**: Added `jsonStringSchema` helper and refactored `updateTaskNotesSchema` to use XOR pattern
- **`src/schemas.test.ts`**: Added comprehensive test suite for XOR validation including edge cases

### Implementation Updates  
- **`src/main.ts`**: Updated tool to extract `html`/`markdown` parameters and create simplified content object
- Updated API documentation resource to reflect new parameter structure

### Documentation Updates
- **`README.md`**: Updated tool description to mention XOR requirement
- **`CLAUDE.md`**: Added XOR schema pattern documentation and test file reference

## Test Plan

- [x] All existing tests pass
- [x] New XOR validation tests pass
- [x] TypeScript compilation succeeds
- [x] Schema correctly rejects both parameters provided
- [x] Schema correctly rejects neither parameter provided  
- [x] Schema correctly accepts exactly one parameter (html OR markdown)
- [x] Tool implementation handles both content types correctly

## Breaking Change

This is a **minor breaking change** to the `update-task-notes` tool API:

**Before:**
```json
{
  "taskId": "123",
  "content": {"html": "<p>content</p>"}
}
```

**After:**
```json
{
  "taskId": "123", 
  "html": "<p>content</p>"
}
```

The new API is cleaner and more explicit about content type requirements.