### PR TITLE
chore: bump sunsama-api to 0.11.2

### DIFF
--- a/.changeset/bump-sunsama-api-0-11-2.md
+++ b/.changeset/bump-sunsama-api-0-11-2.md
@@ -1,0 +1,5 @@
+---
+"mcp-sunsama": patch
+---
+
+Bump sunsama-api to version 0.11.2

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "papaparse": "^5.5.3",
-        "sunsama-api": "0.11.1",
+        "sunsama-api": "0.11.2",
         "zod": "3.24.4",
       },
       "devDependencies": {
@@ -396,7 +396,7 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
-    "sunsama-api": ["sunsama-api@0.11.1", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "marked": "^14.1.3", "tough-cookie": "^5.1.2", "tslib": "^2.8.1", "turndown": "^7.2.0", "yjs": "^13.6.27", "zod": "^3.25.64" } }, "sha512-+2vhhswHXg1Bv3oA21Jj6UEojqsBnh6+Nu2IcOs8KA+fAEHwPITNjpEW4aYh7/jBBmGDkAssZ6zimRV/rmZh4A=="],
+    "sunsama-api": ["sunsama-api@0.11.2", "", { "dependencies": { "graphql": "^16.11.0", "graphql-tag": "^2.12.6", "marked": "^14.1.3", "tough-cookie": "^5.1.2", "tslib": "^2.8.1", "turndown": "^7.2.0", "yjs": "^13.6.27", "zod": "^3.25.64" } }, "sha512-tyBrCai6Z0jEmRXkwGY+0PlXJTAwE3IJXXRCDcGFwpFPxFO5fyxw6mqM/RhYu7OGhP3AF7w4CikvEOBDaFXvKA=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "papaparse": "^5.5.3",
-    "sunsama-api": "0.11.1",
+    "sunsama-api": "0.11.2",
     "zod": "3.24.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bump sunsama-api dependency from 0.11.1 to 0.11.2

## Changes
- Update package.json with new version
- Update bun.lock
- Add changeset for patch release

## Test plan
- [ ] Verify dependencies install correctly
- [ ] Run unit tests: `bun test:unit`
- [ ] Run integration tests: `bun test:integration`
- [ ] Build succeeds: `bun run build`