### PR TITLE
Fix TypeScript build by excluding __tests__ from compilation

### DIFF
--- a/.changeset/fix-package-bin-path.md
+++ b/.changeset/fix-package-bin-path.md
@@ -1,0 +1,5 @@
+---
+"mcp-sunsama": patch
+---
+
+Fix TypeScript build output by excluding __tests__ from compilation. Version 0.15.2 broke because TypeScript was compiling both src/ and __tests__/ directories, causing files to be output to dist/src/ instead of dist/. Now excludes __tests__ so production code builds directly to dist/.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   },
   "exclude": [
     "dist",
-    "node_modules"
+    "node_modules",
+    "__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
Fixes broken v0.15.2 by excluding `__tests__` directory from TypeScript compilation.

## Root Cause
Version 0.15.2 broke because TypeScript was compiling both `src/` and `__tests__/` directories. Without an explicit `rootDir`, TypeScript inferred the project root from all input files, causing:
- Build output to `dist/src/main.js` instead of `dist/main.js`
- Package.json pointed to `dist/main.js` (correct path)
- But file didn't exist → `npx mcp-sunsama` failed with "command not found"

Version 0.15.1 worked accidentally because a stale `dist/main.js` file was included in the published package.

## Solution
Added `__tests__` to tsconfig.json exclude list. This is the correct approach because:
- ✅ Test files don't need to be in published packages
- ✅ Bun's test runner compiles TypeScript tests separately
- ✅ Output structure is cleaner (dist/ only contains production code)
- ✅ Package size reduced by ~7KB (87.5 KB vs 94.3 KB)
- ✅ File count reduced (103 vs 114 files)

## Changes
- `tsconfig.json`: Added `"__tests__"` to exclude array
- `.changeset/fix-package-bin-path.md`: Added changeset for patch release

## Testing
- ✅ Clean build produces files at `dist/main.js` (not `dist/src/main.js`)
- ✅ Packed package verified correct structure
- ✅ Verified bin path points to existing file
- ✅ All unit tests pass

This will be released as v0.15.3.