### PR TITLE
fix: add postbuild script to set executable permissions on bin file

### DIFF
--- a/.changeset/executable-permissions.md
+++ b/.changeset/executable-permissions.md
@@ -1,0 +1,5 @@
+---
+"mcp-sunsama": patch
+---
+
+Fix executable permissions on bin file by adding postbuild script. Adds chmod +x to ensure dist/main.js is executable after build, resolving 'Permission denied' error when running via npx.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "bunx tsc --noEmit",
     "typecheck:watch": "bunx tsc --noEmit --watch",
     "build": "bunx tsc",
+    "postbuild": "chmod +x dist/main.js",
     "inspect": "bunx @modelcontextprotocol/inspector --config ./mcp-inspector.json --server sunsama",
     "changeset": "changeset",
     "version": "changeset version",


### PR DESCRIPTION
## Summary
Fixes permission denied error (code 126) when running via npx by adding postbuild script to set executable permissions on dist/main.js.

## Root Cause
- v0.15.3 was published with dist/main.js lacking executable permissions
- TypeScript compiler doesn't set executable permissions on output files
- npm preserves file permissions from build time when publishing

## Solution
Added `postbuild` script to package.json:
```json
"postbuild": "chmod +x dist/main.js"
```

This ensures dist/main.js is executable after every build.

## Testing
- ✅ Clean build produces executable file (verified with `ls -la`)
- ✅ Postbuild script runs automatically after TypeScript compilation

Fixes permission denied error reported in v0.15.3.