### PR TITLE
fix: update-task-notes schema for MCP SDK compatibility

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -200,7 +200,9 @@ export const updateTaskPlannedTimeSchema = z.object({
   ),
 });
 
-// Update task notes parameters with XOR content validation
+// Update task notes parameters
+// Note: XOR validation between html/markdown is done in the tool execute function
+// to keep the schema as a plain ZodObject (required for MCP SDK compatibility)
 export const updateTaskNotesSchema = z.object({
   taskId: z.string().min(1, "Task ID is required").describe(
     "The ID of the task to update notes for",
@@ -214,18 +216,7 @@ export const updateTaskNotesSchema = z.object({
   limitResponsePayload: z.boolean().optional().describe(
     "Whether to limit the response payload size (defaults to true)",
   ),
-}).refine(
-  (data) => {
-    // Exactly one of html or markdown must be provided
-    const hasHtml = data.html !== undefined;
-    const hasMarkdown = data.markdown !== undefined;
-    return hasHtml !== hasMarkdown; // XOR: exactly one must be true
-  },
-  {
-    message: "Exactly one of 'html' or 'markdown' must be provided",
-    path: [], // This will show the error at the root level
-  },
-);
+});
 
 // Update task due date parameters
 export const updateTaskDueDateSchema = z.object({

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -295,6 +295,13 @@ export const updateTaskNotesTool = withTransportClient({
     { taskId, html, markdown, limitResponsePayload }: UpdateTaskNotesInput,
     context: ToolContext,
   ) => {
+    // XOR validation: exactly one of html or markdown must be provided
+    const hasHtml = html !== undefined;
+    const hasMarkdown = markdown !== undefined;
+    if (hasHtml === hasMarkdown) {
+      throw new Error("Exactly one of 'html' or 'markdown' must be provided");
+    }
+
     const content = html
       ? { type: "html" as const, value: html }
       : { type: "markdown" as const, value: markdown! };


### PR DESCRIPTION
## Summary

Fixes #28 

The `update-task-notes` tool was failing with `MCP error -32603: keyValidator._parse is not a function` because the schema used Zod's `.refine()` method, which transforms the `ZodObject` into a `ZodEffects` type that the MCP SDK cannot properly parse.

## Changes

1. **`src/schemas.ts`**: Removed `.refine()` from `updateTaskNotesSchema` to keep it as a plain `ZodObject`
2. **`src/tools/task-tools.ts`**: Added XOR validation in the `execute` function to ensure exactly one of `html` or `markdown` is provided

## Why This Fix Works

- The MCP SDK expects a `ZodObject` with a `.shape` property to extract field definitions for tool registration
- `ZodEffects` (created by `.refine()`) wraps the original schema and doesn't expose `.shape` the same way
- By moving the validation to runtime, we maintain the same behavior while keeping MCP SDK compatibility

## Testing

- [ ] Call `update-task-notes` with valid `taskId` and `markdown` content
- [ ] Call `update-task-notes` with valid `taskId` and `html` content  
- [ ] Verify error when both `html` and `markdown` are provided
- [ ] Verify error when neither `html` nor `markdown` are provided
