### PR TITLE
chore: add changeset for update-task-notes fix

### DIFF
--- a/.changeset/fix-update-task-notes-schema.md
+++ b/.changeset/fix-update-task-notes-schema.md
@@ -1,0 +1,6 @@
+---
+"mcp-sunsama": patch
+---
+
+Fix update-task-notes tool failing with MCP error -32603. Removed Zod `.refine()` from schema which was causing MCP SDK to fail parsing the tool parameters. XOR validation between html/markdown is now handled at runtime.
+


### PR DESCRIPTION
Adds the missing changeset for the update-task-notes schema fix (PR #29).