### PR TITLE
feat(auth): add session token authentication support

### DIFF
--- a/src/auth/stdio.ts
+++ b/src/auth/stdio.ts
@@ -7,12 +7,22 @@ let authenticationPromise: Promise<SunsamaClient> | null = null;
 
 /**
  * Initialize stdio authentication using environment variables
+ * Supports session token (SUNSAMA_SESSION_TOKEN) or email/password (SUNSAMA_EMAIL, SUNSAMA_PASSWORD)
  * @throws {Error} If credentials are missing or authentication fails
  */
 export async function initializeStdioAuth(): Promise<SunsamaClient> {
+  // Prefer session token if available (useful for Google SSO users)
+  if (process.env.SUNSAMA_SESSION_TOKEN) {
+    const sunsamaClient = new SunsamaClient({
+      sessionToken: process.env.SUNSAMA_SESSION_TOKEN
+    });
+    return sunsamaClient;
+  }
+
+  // Fall back to email/password authentication
   if (!process.env.SUNSAMA_EMAIL || !process.env.SUNSAMA_PASSWORD) {
     throw new Error(
-      "Sunsama credentials not configured. Please set SUNSAMA_EMAIL and SUNSAMA_PASSWORD environment variables."
+      "Sunsama credentials not configured. Please set SUNSAMA_SESSION_TOKEN or both SUNSAMA_EMAIL and SUNSAMA_PASSWORD environment variables."
     );
   }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -5,7 +5,7 @@ import { SunsamaClient } from "sunsama-api/client";
  */
 export interface SessionData extends Record<string, unknown> {
   sunsamaClient: SunsamaClient;
-  email: string;
+  email?: string;
   createdAt: number;
   lastAccessedAt: number;
 }


### PR DESCRIPTION
## Summary

Add support for authenticating with Sunsama session tokens, enabling users who sign in with Google SSO (or other OAuth providers) to use the MCP server without email/password credentials.

### Changes

- **stdio transport**: Support `SUNSAMA_SESSION_TOKEN` environment variable as an alternative to `SUNSAMA_EMAIL`/`SUNSAMA_PASSWORD`
- **http transport**: Support Bearer token authentication alongside existing Basic Auth
- **types**: Make `email` optional in `SessionData` for token-based auth

### Motivation

Many Sunsama users authenticate via Google or other SSO providers and don't have a Sunsama password. The underlying `sunsama-api` library already supports session token authentication via `new SunsamaClient({ sessionToken })`, but the MCP server didn't expose this capability.

### Usage

**For stdio transport (Claude Code, Claude Desktop):**
```json
{
  "sunsama": {
    "command": "node",
    "args": ["/path/to/mcp-sunsama/dist/main.js"],
    "env": {
      "SUNSAMA_SESSION_TOKEN": "your-session-token"
    }
  }
}
```

**For HTTP transport:**
```
Authorization: Bearer <session-token>
```

Session tokens can be obtained from the `sunsamaSession` cookie after logging into Sunsama in a browser.

## Test plan

- [x] Tested stdio transport with session token authentication
- [ ] Verified backward compatibility with email/password authentication