### PR TITLE
fix: handle undefined integration identifier in task trimmer

### DIFF
--- a/src/utils/task-trimmer.ts
+++ b/src/utils/task-trimmer.ts
@@ -61,7 +61,7 @@ export function trimTaskForResponse(task: Task): TrimmedTask {
   // Integration identifiers vary by service - some have URLs (websites), others have different properties
   if (task.integration) {
     integration = { service: task.integration.service };
-    if ("url" in task.integration.identifier) {
+    if (task.integration.identifier && "url" in task.integration.identifier) {
       integration.url = task.integration.identifier.url;
     }
   }


### PR DESCRIPTION
Fixes bug where get-tasks-by-day would crash with "Cannot use 'in' operator to search for 'url' in undefined" when tasks had integrations with undefined/null identifier properties.

The issue occurred in trimTaskForResponse() which checked for 'url' in task.integration.identifier without first verifying that identifier exists.

Changes:
- Add null check before using 'in' operator on integration.identifier
- Properly handles all edge cases: no integration, no identifier, no url property, and valid url property

This fix ensures get-tasks-by-day works correctly for all task types.